### PR TITLE
엔티티 클래스 추가 및 예외 처리 세팅 추가

### DIFF
--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
@@ -2,6 +2,12 @@ package com.gsmNetworking.auth.domain.auth.domain
 
 import javax.persistence.*
 
+/**
+ * 권한 정보를 저장하는 Entity 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
 @Entity
 class Authentication(
     @Id

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
@@ -4,9 +4,6 @@ import javax.persistence.*
 
 /**
  * 권한 정보를 저장하는 Entity 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 @Entity
 class Authentication(

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authentication.kt
@@ -1,0 +1,13 @@
+package com.gsmNetworking.auth.domain.auth.domain
+
+import javax.persistence.*
+
+@Entity
+class Authentication(
+    @Id
+    val email: String,
+    @Column(name = "provider_id", nullable = false)
+    val providerId: String,
+    @Enumerated(EnumType.STRING)
+    val authority: Authority
+)

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
@@ -1,5 +1,11 @@
 package com.gsmNetworking.auth.domain.auth.domain
 
+/**
+ * 사용자의 권한을 판별하는 enum 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
 enum class Authority {
 
     ROLE_UNAUTHENTICATED,

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
@@ -2,9 +2,6 @@ package com.gsmNetworking.auth.domain.auth.domain
 
 /**
  * 사용자의 권한을 판별하는 enum 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 enum class Authority {
 

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/Authority.kt
@@ -1,0 +1,9 @@
+package com.gsmNetworking.auth.domain.auth.domain
+
+enum class Authority {
+
+    ROLE_UNAUTHENTICATED,
+    ROLE_USER,
+    ROLE_ADMIN
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -1,0 +1,14 @@
+package com.gsmNetworking.auth.domain.auth.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+@RedisHash
+data class RefreshToken(
+    @Id
+    val token: String,
+    val email: String,
+    @TimeToLive
+    val expirationTime: Int
+)

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -4,6 +4,12 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
 
+/**
+ * 재발급 토큰 정보를 저장하는 RedisHash 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
 @RedisHash
 data class RefreshToken(
     @Id

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -6,9 +6,6 @@ import org.springframework.data.redis.core.TimeToLive
 
 /**
  * 재발급 토큰 정보를 저장하는 RedisHash 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 @RedisHash
 data class RefreshToken(

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
@@ -3,6 +3,12 @@ package com.gsmNetworking.auth.domain.auth.repository
 import com.gsmNetworking.auth.domain.auth.domain.Authentication
 import org.springframework.data.repository.CrudRepository
 
+/**
+ * Authentication Entity를 위한 Repository 인터페이스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
 interface AuthenticationRepository: CrudRepository<Authentication, String> {
 
     fun findByProviderId(providerId: String): Authentication?

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
@@ -5,9 +5,6 @@ import org.springframework.data.repository.CrudRepository
 
 /**
  * Authentication Entity를 위한 Repository 인터페이스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 interface AuthenticationRepository: CrudRepository<Authentication, String> {
 

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
@@ -1,0 +1,10 @@
+package com.gsmNetworking.auth.domain.auth.repository
+
+import com.gsmNetworking.auth.domain.auth.domain.Authentication
+import org.springframework.data.repository.CrudRepository
+
+interface AuthenticationRepository: CrudRepository<Authentication, String> {
+
+    fun findByProviderId(providerId: String): Authentication?
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
@@ -3,4 +3,10 @@ package com.gsmNetworking.auth.domain.auth.repository
 import com.gsmNetworking.auth.domain.auth.domain.RefreshToken
 import org.springframework.data.repository.CrudRepository
 
+/**
+ * RefreshToken Entity를 위한 Repository 인터페이스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
 interface RefreshTokenRepository: CrudRepository<RefreshToken, String>

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
@@ -5,8 +5,5 @@ import org.springframework.data.repository.CrudRepository
 
 /**
  * RefreshToken Entity를 위한 Repository 인터페이스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 interface RefreshTokenRepository: CrudRepository<RefreshToken, String>

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
@@ -1,0 +1,6 @@
+package com.gsmNetworking.auth.domain.auth.repository
+
+import com.gsmNetworking.auth.domain.auth.domain.RefreshToken
+import org.springframework.data.repository.CrudRepository
+
+interface RefreshTokenRepository: CrudRepository<RefreshToken, String>

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
@@ -1,6 +1,5 @@
 package com.gsmNetworking.auth.global.exception
 
-import com.gsmNetworking.auth.global.exception.model.ErrorCode
 import org.springframework.http.HttpStatus
 
 /**
@@ -8,17 +7,5 @@ import org.springframework.http.HttpStatus
  */
 class ExpectedException(
     val status: HttpStatus,
-    override val message: String,
-    val errorCode: ErrorCode
-): RuntimeException(message) {
-
-    /**
-     * 분기처리가 필요하지 않은 상황일때 사용되는 생성자 입니다.
-     */
-    constructor(status: HttpStatus, message: String): this(
-        status = status,
-        message = message,
-        errorCode = ErrorCode.EXCEPTION
-    )
-
-}
+    override val message: String
+): RuntimeException(message)

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
@@ -1,5 +1,6 @@
 package com.gsmNetworking.auth.global.exception
 
+import com.gsmNetworking.auth.global.exception.model.ErrorCode
 import org.springframework.http.HttpStatus
 
 /**
@@ -7,5 +8,17 @@ import org.springframework.http.HttpStatus
  */
 class ExpectedException(
     val status: HttpStatus,
-    override val message: String
-): RuntimeException(message)
+    override val message: String,
+    val errorCode: ErrorCode
+): RuntimeException(message) {
+
+    /**
+     * 분기처리가 필요하지 않은 상황일때 사용되는 생성자 입니다.
+     */
+    constructor(status: HttpStatus, message: String): this(
+        status = status,
+        message = message,
+        errorCode = ErrorCode.EXCEPTION
+    )
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
@@ -1,0 +1,14 @@
+package com.gsmNetworking.auth.global.exception
+
+import org.springframework.http.HttpStatus
+
+/**
+ * 클라이언트에게 예외 상황에 HttpStatus와 Message를 전달해주기 위해 사용되는 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
+class ExpectedException(
+    val status: HttpStatus,
+    override val message: String
+): RuntimeException(message)

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/ExpectedException.kt
@@ -4,9 +4,6 @@ import org.springframework.http.HttpStatus
 
 /**
  * 클라이언트에게 예외 상황에 HttpStatus와 Message를 전달해주기 위해 사용되는 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 class ExpectedException(
     val status: HttpStatus,

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
@@ -8,9 +8,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 /**
  * 전역적으로 예외 클래스를 핸들링 하는 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 @RestControllerAdvice
 class GlobalExceptionHandler {

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
@@ -1,0 +1,30 @@
+package com.gsmNetworking.auth.global.exception.handler
+
+import com.gsmNetworking.auth.global.exception.ExpectedException
+import com.gsmNetworking.auth.global.exception.model.ExceptionResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * 전역적으로 예외 클래스를 핸들링 하는 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    /**
+     * ExpectedException과 ExpectedException을 상속받은 예외 클래스를 핸들해는 메서드 입니다.
+     *
+     * @param e {ExpectedException과 ExpectedException을 상속하는 클래스}
+     * @return ExceptionResponse
+     */
+    @ExceptionHandler(ExpectedException::class)
+    fun handler(e: ExpectedException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity
+            .status(e.status)
+            .body(ExceptionResponse(e.message))
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
@@ -22,11 +22,6 @@ class GlobalExceptionHandler {
     fun handler(e: ExpectedException): ResponseEntity<ExceptionResponse> =
         ResponseEntity
             .status(e.status)
-            .body(
-                ExceptionResponse(
-                    message = e.message,
-                    errorCode = e.errorCode
-                )
-            )
+            .body(ExceptionResponse(message = e.message))
 
 }

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/handler/GlobalExceptionHandler.kt
@@ -15,13 +15,18 @@ class GlobalExceptionHandler {
     /**
      * ExpectedException과 ExpectedException을 상속받은 예외 클래스를 핸들해는 메서드 입니다.
      *
-     * @param e {ExpectedException과 ExpectedException을 상속하는 클래스}
+     * @param e {ExpectedException 혹은 ExpectedException을 상속하는 클래스}
      * @return ExceptionResponse
      */
     @ExceptionHandler(ExpectedException::class)
     fun handler(e: ExpectedException): ResponseEntity<ExceptionResponse> =
         ResponseEntity
             .status(e.status)
-            .body(ExceptionResponse(e.message))
+            .body(
+                ExceptionResponse(
+                    message = e.message,
+                    errorCode = e.errorCode
+                )
+            )
 
 }

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ErrorCode.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ErrorCode.kt
@@ -1,0 +1,11 @@
+package com.gsmNetworking.auth.global.exception.model
+
+/**
+ * 클라이언트에서 예외 상황에 따라 분기 처리를 할때 구분하는 클래스 입니다.
+ */
+enum class ErrorCode {
+
+    EXCEPTION
+    ;
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ErrorCode.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ErrorCode.kt
@@ -2,6 +2,7 @@ package com.gsmNetworking.auth.global.exception.model
 
 /**
  * 클라이언트에서 예외 상황에 따라 분기 처리를 할때 구분하는 클래스 입니다.
+ * 현재 V1 에서는 사용하지 않고, 추후 에러 코드를 사용하여 리펙토링 할 시에 사용 할 예정입니다.
  */
 enum class ErrorCode {
 

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
@@ -4,5 +4,6 @@ package com.gsmNetworking.auth.global.exception.model
  * Exception 발생시 클라이언트에게 반환 할 Response 클래스 입니다.
  */
 class ExceptionResponse(
-    val message: String
+    val message: String,
+    val errorCode: ErrorCode
 )

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
@@ -4,6 +4,5 @@ package com.gsmNetworking.auth.global.exception.model
  * Exception 발생시 클라이언트에게 반환 할 Response 클래스 입니다.
  */
 class ExceptionResponse(
-    val message: String,
-    val errorCode: ErrorCode
+    val message: String
 )

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
@@ -2,9 +2,6 @@ package com.gsmNetworking.auth.global.exception.model
 
 /**
  * Exception 발생시 클라이언트에게 반환 할 Response 클래스 입니다.
- *
- * @author 김성길
- * @since 1.0.0
  */
 class ExceptionResponse(
     val message: String

--- a/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/exception/model/ExceptionResponse.kt
@@ -1,0 +1,11 @@
+package com.gsmNetworking.auth.global.exception.model
+
+/**
+ * Exception 발생시 클라이언트에게 반환 할 Response 클래스 입니다.
+ *
+ * @author 김성길
+ * @since 1.0.0
+ */
+class ExceptionResponse(
+    val message: String
+)


### PR DESCRIPTION
## 개요
- 사용자 인증 정보, 토큰 정보를 저장하는 엔티티 클래스가 필요했습니다.
- 예외 상황에 커스텀 예외를 클라이언트에게 발생시킬 예외 클래스 및 예외 핸들러가 필요했습니다.

## 본문
- 사용자의 인증 정보, 토큰 정보를 저장하는 엔티티 클래스를 추가하였습니다.
- 예외 상황에 예외를 발생 시키는 예외 클래스와 예외 클래스를 핸들링 하는 핸들러 클래스를 추가하였습니다. 
