### PR TITLE
토큰 재발급 기능 추가

### DIFF
--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/controller/AuthController.kt
@@ -1,0 +1,22 @@
+package com.gsmNetworking.auth.domain.auth.controller
+
+import com.gsmNetworking.auth.domain.auth.service.ReissueTokenService
+import com.gsmNetworking.auth.global.security.jwt.dto.TokenResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/v1/auth")
+class AuthController(
+    private val reissueTokenService: ReissueTokenService
+) {
+
+    @PatchMapping("/reissue")
+    fun reissueToken(@RequestHeader refreshToken: String): ResponseEntity<TokenResponse> =
+        reissueTokenService.execute(refreshToken)
+            .let { ResponseEntity.ok(it) }
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -8,13 +8,13 @@ import org.springframework.data.redis.core.index.Indexed
 /**
  * 재발급 토큰 정보를 저장하는 RedisHash 클래스 입니다.
  */
-@RedisHash
+@RedisHash("refresh_token_test")
 data class RefreshToken(
     @Id
-    val token: String,
+    val email: String,
 
     @Indexed
-    val email: String,
+    val token: String,
 
     @TimeToLive
     val expirationTime: Int

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -3,6 +3,7 @@ package com.gsmNetworking.auth.domain.auth.domain
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
+import org.springframework.data.redis.core.index.Indexed
 
 /**
  * 재발급 토큰 정보를 저장하는 RedisHash 클래스 입니다.
@@ -10,8 +11,11 @@ import org.springframework.data.redis.core.TimeToLive
 @RedisHash
 data class RefreshToken(
     @Id
-    val email: String,
     val token: String,
+
+    @Indexed
+    val email: String,
+
     @TimeToLive
     val expirationTime: Int
 )

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/domain/RefreshToken.kt
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.index.Indexed
 /**
  * 재발급 토큰 정보를 저장하는 RedisHash 클래스 입니다.
  */
-@RedisHash("refresh_token_test")
+@RedisHash("refresh_token")
 data class RefreshToken(
     @Id
     val email: String,

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/AuthenticationRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.CrudRepository
  */
 interface AuthenticationRepository: CrudRepository<Authentication, String> {
 
+    fun findByEmail(email: String): Authentication?
     fun findByProviderId(providerId: String): Authentication?
 
 }

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
@@ -6,4 +6,8 @@ import org.springframework.data.repository.CrudRepository
 /**
  * RefreshToken Entity를 위한 Repository 인터페이스 입니다.
  */
-interface RefreshTokenRepository: CrudRepository<RefreshToken, String>
+interface RefreshTokenRepository: CrudRepository<RefreshToken, String> {
+
+    fun findByEmail(email: String): RefreshToken
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/repository/RefreshTokenRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.data.repository.CrudRepository
  */
 interface RefreshTokenRepository: CrudRepository<RefreshToken, String> {
 
-    fun findByEmail(email: String): RefreshToken
+    fun findByToken(token: String): RefreshToken?
 
 }

--- a/src/main/kotlin/com/gsmNetworking/auth/domain/auth/service/ReissueTokenService.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/domain/auth/service/ReissueTokenService.kt
@@ -1,0 +1,64 @@
+package com.gsmNetworking.auth.domain.auth.service
+
+import com.gsmNetworking.auth.domain.auth.domain.RefreshToken
+import com.gsmNetworking.auth.domain.auth.repository.AuthenticationRepository
+import com.gsmNetworking.auth.domain.auth.repository.RefreshTokenRepository
+import com.gsmNetworking.auth.global.exception.ExpectedException
+import com.gsmNetworking.auth.global.security.jwt.TokenGenerator
+import com.gsmNetworking.auth.global.security.jwt.TokenParser
+import com.gsmNetworking.auth.global.security.jwt.dto.TokenResponse
+import com.gsmNetworking.auth.global.security.jwt.properties.JwtExpTimeProperties
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 로그인 연장을 위한 토큰 재발급을 해주는 서비스 클래스 입니다.
+ */
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class ReissueTokenService(
+    private val tokenParser: TokenParser,
+    private val tokenGenerator: TokenGenerator,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val authenticationRepository: AuthenticationRepository,
+    private val jwtExpTimeProperties: JwtExpTimeProperties
+) {
+
+    /**
+     * 유효한 RefreshToken 이라면 Token을 리턴하고, 유효하지 않은 RefreshToken 이라면 예외를 던집니다.
+     *
+     * @param token 로그인 연장에 필요한 재발급(RefreshToken) 토큰
+     * @throws ExpectedException 이 터지는 조건은 아래와 같다.
+     *      1. RefreshToken Entity에 저장되지 않은 RefreshToken일 경우
+     *      2. RefreshToken의 Subject가 저장되지 않은 경우
+     *      3. 유효하지 않은 Token Prefix로 요청 한 경우
+     * @return TokenResponse
+     */
+    fun execute(token: String): TokenResponse {
+        val parsedToken = tokenParser.parseRefreshToken(token)
+        val refreshToken = refreshTokenRepository.findByIdOrNull(parsedToken)
+            ?: throw ExpectedException(HttpStatus.NOT_FOUND, "존재하지 않는 refresh token 입니다.")
+        val authentication = authenticationRepository.findByEmail(refreshToken.email)
+            ?: throw ExpectedException(HttpStatus.NOT_FOUND, "refresh token subject인 email을 찾을 수 없습니다.")
+        val tokenDto = tokenGenerator.generateToken(refreshToken.email, authentication.authority)
+        saveRefreshToken(tokenDto.refreshToken, authentication.email)
+        deleteBeforeRefreshToken(refreshToken)
+        return tokenDto
+    }
+
+    private fun saveRefreshToken(token: String, email: String) {
+        val refreshToken = RefreshToken(
+            token = token,
+            email = email,
+            expirationTime = jwtExpTimeProperties.refreshExp
+        )
+        refreshTokenRepository.save(refreshToken)
+    }
+
+    private fun deleteBeforeRefreshToken(refreshToken: RefreshToken) {
+        refreshTokenRepository.delete(refreshToken)
+    }
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/config/RedisConfig.kt
@@ -1,0 +1,25 @@
+package com.gsmNetworking.auth.global.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+@Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP) // Redis Key Space Notifications 기능 활성화
+class RedisConfig(
+    @Value("\${spring.redis.host}")
+    private val redisHost: String,
+    @Value("\${spring.redis.port}")
+    private val redisPort: Int
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        return LettuceConnectionFactory(redisHost, redisPort)
+    }
+
+}

--- a/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomLogoutSuccessHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomLogoutSuccessHandler.kt
@@ -2,7 +2,9 @@ package com.gsmNetworking.auth.global.security.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.gsmNetworking.auth.domain.auth.repository.RefreshTokenRepository
+import com.gsmNetworking.auth.global.exception.ExpectedException
 import com.gsmNetworking.auth.global.security.oauth.properties.Oauth2Properties
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
@@ -30,8 +32,9 @@ class CustomLogoutSuccessHandler(
     ) {
         response.status = HttpServletResponse.SC_OK
         if (authentication != null) {
-            val refreshToken = refreshTokenRepository.findByEmail(authentication.name)
-            refreshTokenRepository.deleteById(refreshToken.token)
+            val refreshToken = refreshTokenRepository.findByIdOrNull(authentication.name)
+                ?: throw ExpectedException(HttpStatus.NOT_FOUND, "존재하지 않는 refresh token 입니다.")
+            refreshTokenRepository.delete(refreshToken)
         } else sendErrorResponse(response)
         response.sendRedirect(oauth2Properties.redirectUri)
     }

--- a/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomLogoutSuccessHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomLogoutSuccessHandler.kt
@@ -30,7 +30,8 @@ class CustomLogoutSuccessHandler(
     ) {
         response.status = HttpServletResponse.SC_OK
         if (authentication != null) {
-            refreshTokenRepository.deleteById(authentication.name)
+            val refreshToken = refreshTokenRepository.findByEmail(authentication.name)
+            refreshTokenRepository.deleteById(refreshToken.token)
         } else sendErrorResponse(response)
         response.sendRedirect(oauth2Properties.redirectUri)
     }

--- a/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomUrlAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomUrlAuthenticationSuccessHandler.kt
@@ -13,10 +13,12 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @Component
+@Transactional(rollbackFor = [Exception::class])
 class CustomUrlAuthenticationSuccessHandler(
     private val tokenGenerator: TokenGenerator,
     private val refreshTokenRepository: RefreshTokenRepository,

--- a/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomUrlAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/security/handler/CustomUrlAuthenticationSuccessHandler.kt
@@ -37,8 +37,8 @@ class CustomUrlAuthenticationSuccessHandler(
 
     private fun saveRefreshToken(token: String, email: String) {
         val refreshToken = RefreshToken(
-            email = email,
             token = token,
+            email = email,
             expirationTime = jwtExpTimeProperties.refreshExp
         )
         refreshTokenRepository.save(refreshToken)

--- a/src/main/kotlin/com/gsmNetworking/auth/global/security/jwt/TokenParser.kt
+++ b/src/main/kotlin/com/gsmNetworking/auth/global/security/jwt/TokenParser.kt
@@ -1,0 +1,28 @@
+package com.gsmNetworking.auth.global.security.jwt
+
+import com.gsmNetworking.auth.global.exception.ExpectedException
+import com.gsmNetworking.auth.global.security.jwt.properties.JwtProperties
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+/**
+ * 토큰을 파싱하는 클래스 입니다.
+ */
+@Component
+class TokenParser {
+
+    /**
+     * 재발급 토큰의 prefix를 파싱하는 역할의 메서드 입니다.
+     *
+     * @param refreshToken prefix를 포함한 refreshToken 입니다.
+     * @throws ExpectedException 이 터지는 조건은 아래와 같다.
+    *       1. jwt의 토큰 prefix인 Bearer이 붙지 않은 경우
+     * @return prefix를 replace한 refreshToken을 반환 합니다.
+     */
+    fun parseRefreshToken(refreshToken: String): String {
+        if (refreshToken.startsWith(JwtProperties.TOKEN_PREFIX))
+            return refreshToken.replace(JwtProperties.TOKEN_PREFIX, "")
+        throw ExpectedException(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token 입니다.")
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,8 +34,8 @@ spring:
       client:
         registration:
           google:
-            client-id: ${CLIENT_ID}
-            client-secret: ${CLIENT_SECRET}
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/login/oauth2/code/google
             scope: profile,email
             success:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,49 @@
+server:
+  shutdown: graceful
+
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+
+  datasource:
+    driver-class-name: ${DB_CLASS_NAME}
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database-platform: ${DB_PLATFORM}
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO}
+
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope: ${GOOGLE_SCOPE}
+            success:
+              redirect-uri: ${GOOGLE_SUCCESS_REDIRECT_URI}
+
+jwt:
+  accessSecret: ${JWT_ACCESS_SECRET}
+  refreshSecret: ${JWT_REFRESH_SECRET}
+  time:
+    accessExp: ${JWT_ACCESS_EXPIRED}
+    refreshExp: ${JWT_REFRESH_EXPIRED}


### PR DESCRIPTION
## 개요
- 로그인 연장을 위한 토큰 재발급 기능을 추가하였습니다.

## 본문

### 추가
- 토큰 재발급 서비스 클래스를 추가하였습니다.
- `email` 컬럼으로 쿼리 메서드를 하기 위해 `@Indexed` 컬럼으로 지정하였습니다.
- `@indexed` 으로 지정한 컬럼은 `ttl`이 지나도 삭제 되지 않는 이슈가 있어, `Redis Config` 설정 클래스를 추가하여 `Key Space Notifications` 모드를 활성화 하였습니다.

### 변경
- `CustomLogoutSuccessHandler`에서 사용자를 한번 검증 후 `refreshToken`을 삭제 하도록 변경하였습니다.